### PR TITLE
Create a test telemetry handler

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,127 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "lexical-lsp": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1695148586,
+        "narHash": "sha256-oOPtYge8XBkjh1jaSvb9iG6/iC2m14nhdSp1zQ6O1YE=",
+        "owner": "lexical-lsp",
+        "repo": "lexical",
+        "rev": "eeef7ea5ab149b3b530238fb71dba5f5f8d06f59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lexical-lsp",
+        "repo": "lexical",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692557222,
+        "narHash": "sha256-TCOtZaioLf/jTEgfa+nyg0Nwq5Uc610Z+OFV75yUgGw=",
+        "path": "/nix/store/7x0565m245dv1ny5j1v04a7azl2kll3a-source",
+        "rev": "0b07d4957ee1bd7fd3bdfd12db5f361bd70175a6",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1694959747,
+        "narHash": "sha256-CXQ2MuledDVlVM5dLC4pB41cFlBWxRw4tCBsFrq3cRk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "lexical-lsp": "lexical-lsp",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "Telemedo as a flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    lexical-lsp.url = "github:lexical-lsp/lexical";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, lexical-lsp }: 
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        inherit (pkgs.lib) optional optionals;
+        pkgs = import nixpkgs { inherit system; };
+        elixir = pkgs.beam.packages.erlang.elixir;
+      in
+      with pkgs;
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = [ 
+            elixir_1_15
+            postgresql_12
+            lexical-lsp.packages.${system}.lexical
+            glibcLocales
+          ] ++ optional stdenv.isLinux inotify-tools;
+        };
+      });
+}

--- a/lib/test_telemetry_handler.ex
+++ b/lib/test_telemetry_handler.ex
@@ -1,0 +1,35 @@
+defmodule Telemedo.TestTelemetryHandler do
+  use Agent
+
+  def start_link(opts) do
+    events = opts[:events]
+    id = opts[:id]
+
+    Agent.start_link(fn ->
+      agent_pid = self()
+
+      :telemetry.attach_many(
+        id,
+        events,
+        fn event, measurements, context, _config ->
+          add_event(agent_pid, [event, measurements, context])
+        end,
+        nil
+      )
+
+      []
+    end)
+  end
+
+  def add_event(agent, event) do
+    Agent.update(agent, fn events -> [event | events] end)
+  end
+
+  def get_event(handler, event_number) do
+    Agent.get(handler, fn events ->
+      events
+      |> Enum.reverse()
+      |> Enum.at(event_number - 1)
+    end)
+  end
+end


### PR DESCRIPTION
Users of the library will want a nice way to hook up to telemetry events
and assert that they happened with the right contextual data. This
helper should make that straightforward.