### PR TITLE
Rename measure to span

### DIFF
--- a/lib/telemetrex.ex
+++ b/lib/telemetrex.ex
@@ -1,5 +1,5 @@
 defmodule Telemetrex do
-  defmacro measure(opts, do: block_do, after: block_after) do
+  defmacro span(opts, do: block_do, after: block_after) do
     metric = opts[:event]
     context = opts[:context]
 

--- a/test/telemetrex_test.exs
+++ b/test/telemetrex_test.exs
@@ -6,7 +6,7 @@ defmodule TelemetrexTest do
     require Telemetrex
 
     def test() do
-      Telemetrex.measure event: [:test], context: %{initial: true} do
+      Telemetrex.span event: [:test], context: %{initial: true} do
         42
       after
         42 ->


### PR DESCRIPTION
This puts it more inline with the wrapped telemetry call and will be easier for users that are familiar with telemetry to be familiar with what Telemetrex is doing.