### PR TITLE
Fix dialyzer error for unreachable code

### DIFF
--- a/lib/telemetrex.ex
+++ b/lib/telemetrex.ex
@@ -120,7 +120,7 @@ defmodule Telemetrex do
         end
       )
 
-    quote do
+    quote generated: true do
       :telemetry.span(unquote(metric), unquote(context), fn ->
         return_value = unquote(block_do)
 
@@ -130,12 +130,14 @@ defmodule Telemetrex do
             unquote(block_after)
           end
 
-        {return_value,
-         if unquote(merge?) do
-           Map.merge(unquote(context), after_meta)
-         else
-           after_meta
-         end}
+        {
+          return_value,
+          if unquote(merge?) do
+            Map.merge(unquote(context), after_meta)
+          else
+            after_meta
+          end
+        }
       end)
     end
   end


### PR DESCRIPTION
Dialyzer was throwing the following error about unreachable/unused code branches in projects
consuming Telemetrex.

```
The pattern can never match the type.

Pattern:false

Type:true
```

Per elixir [docs](https://hexdocs.pm/elixir/1.15/Kernel.SpecialForms.html#quote/2-options),
`generated: true` informs the compiler to not issue warnings on unused code in libraries.